### PR TITLE
Add environment variable to restrict certain keytypes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,11 @@ submission deadlines:
   environment variable (to any value) causes these links to be shown
   regardless of whether or not the deadline has passed.
 
+``RESTRICTEDTYPES``
+  A comma-delimited list of keytypes that will not be accepted. Types are
+  defined as the type in the output of a fingerprint identifer for the key
+  For example, disabling 2048-RSA keys and 1024DSA keys: ``2048R,1024D``
+
 A configuration for Apache with mod_wsgi might be::
 
     <Directory /usr/home/joe/pgpsubmit>

--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,15 @@ submission deadlines:
   environment variable (to any value) causes these links to be shown
   regardless of whether or not the deadline has passed.
 
-``RESTRICTEDTYPES``
-  A comma-delimited list of keytypes that will not be accepted. Types are
-  defined as the type in the output of a fingerprint identifer for the key
-  For example, disabling 2048-RSA keys and 1024DSA keys: ``2048R,1024D``
+``RESTRICTEDALGORITHM``
+  A comma-delimited list of public key algorithms to be restricted. 
+  Obtained by executing ``gpg --with-colon`` on imported key. ID to Type mapping
+  list in ``pgpsubmitlib/gpg.py``
+  Example setting: ``17`` will restrict any DSA-encrypted keys from being imported
+
+``MINIMUMLENGTH``
+  The minimum key-length of any imported key. For example, setting to ``4096`` will
+  only allow keys 4096bits or larger to be imported 
 
 A configuration for Apache with mod_wsgi might be::
 
@@ -81,6 +86,8 @@ A configuration for Apache with mod_wsgi might be::
         SetEnv GNUPGHOME /usr/home/joe/.pgpsubmit
         SetEnv PGPSUBMITSOURCEURL https://github.com/frasertweedale/pgpsubmit
         SetEnv PGPSUBMITUNTIL 2011.12.31.18.30
+        SetEnv MINIMUMLENGTH 2048
+        SetEnv RESTRICTEDALGORITHM 17,18,19
     </VirtualHost>
 
 

--- a/pgpsubmitlib/pgp.py
+++ b/pgpsubmitlib/pgp.py
@@ -47,6 +47,9 @@ PUB_ALGS = [
     "Reserved for Diffie-Hellman",
 ]
 
+# ECC Curve equivelent RSA Lenegth. https://tools.ietf.org/html/rfc6637#section-13
+ECC_EQUIV_LENGTH = { "256": 3072, "384": 7680, "521": 15360}
+
 def paragraphs(lines):
     """Given iterable of lines, yield paragraphs of joined lines."""
     para = []
@@ -63,7 +66,6 @@ def paragraphs(lines):
 def get_key_id(para):
     """Extract the key ID from the given paragraph."""
     return re.match(r'pub\s+\w+/([\dA-F]*)', para).group(1)
-
 
 class Keyring(object):
     """GnuPG keyring interface.
@@ -125,8 +127,9 @@ class Keyring(object):
         lines = [l for l in stdout.splitlines() if pattern.match(l)]
         pub = lines[0].split(":")
         algorithm = pub[3]
-        if algorithm in ['18', '19', '22']: 
-            length = pub[16]
+        if algorithm in ["18", "19", "22"]: #ECC Curve, find equiv. length 
+            curve = pub[2]
+            length = ECC_EQUIV_LENGTH[curve]
         else: 
             length = pub[2]
     


### PR DESCRIPTION
Per request in http://lists.lca2015.linux.org.au/pipermail/chat/2014-December/000118.html, I've added optional functionality to restrict weaker keys. Logic around finding the keytype follows. This may not be the best way to find out this information, but I couldn't find a saner alternative that didn't require importing possibly-bad keys into the keyring, then removing them again. 

---

The gpg command `--with-fingerprint` allows the parsing of an
ASCII-armored public key without the importing of said key into the
keyring. This can be used to check the strength of a key, and possibly
reject it from being submitted.

Sample fingerprint header: `pub  1024R/AABBCCDDEE 2011-11-11`
In this case, the type is parsed as `1024R`.

Environment variable format is any type of `^pub(\s*)(.+?)/` to
disclude. Example: `1024D,2048R` will reject 1024-DSA and 2048RDA keys.
In the above sample fingerprint header, this key would be rejected.

By default, all key types are allowed.
